### PR TITLE
Space after text label for mortality rate.

### DIFF
--- a/src/stromrechner/views.cljs
+++ b/src/stromrechner/views.cljs
@@ -291,7 +291,7 @@
      [:div.column
       [energy-mix]
       [energy-needed]]]
-    [indicator "Statistisch erwartbare Todesfälle pro Jahr:"
+    [indicator "Statistisch erwartbare Todesfälle pro Jahr: "
      :deaths]
     [indicator "Jährlicher CO2-Ausstoß: "
      :co2]]


### PR DESCRIPTION
Fixes spelling.